### PR TITLE
Minor changes

### DIFF
--- a/draft-tgraf-netconf-notif-sequencing-00.txt
+++ b/draft-tgraf-netconf-notif-sequencing-00.txt
@@ -19,8 +19,9 @@ Abstract
    This document specifies a new YANG module that augment the NETCONF
    Event Notification header to support hostname and sequence numbers to
    identify from which network node and at which time the message was
-   published.  This allows to recognize loss, delay and reordering
-   between the publisher and the downstream system storing the message.
+   published.  This allows the collector to recognize loss, delay and
+   reordering between the publisher and the downstream system storing
+   the message.
 
 Status of This Memo
 
@@ -44,12 +45,11 @@ Copyright Notice
    Copyright (c) 2023 IETF Trust and the persons identified as the
    document authors.  All rights reserved.
 
-
-
-
-
-
-
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents (https://trustee.ietf.org/
+   license-info) in effect on the date of publication of this document.
+   Please review these documents carefully, as they describe your rights
+   and restrictions with respect to this document.  Code Components
 
 
 
@@ -58,11 +58,6 @@ Graf, et al.            Expires 6 September 2023                [Page 1]
 Internet-Draft        YANG Notifications Sequencing           March 2023
 
 
-   This document is subject to BCP 78 and the IETF Trust's Legal
-   Provisions Relating to IETF Documents (https://trustee.ietf.org/
-   license-info) in effect on the date of publication of this document.
-   Please review these documents carefully, as they describe your rights
-   and restrictions with respect to this document.  Code Components
    extracted from this document must include Revised BSD License text as
    described in Section 4.e of the Trust Legal Provisions and are
    provided without warranty as described in the Revised BSD License.
@@ -89,15 +84,15 @@ Table of Contents
 
 1.  Introduction
 
-   [RFC5277] describes the NETCONF event notification header using a XML
-   Schema.  In the metadata of the event notification header, only the
-   eventTime is present indicating at which time the notification
-   message was published.  For other encodings, the same schema is
-   implemented using a YANG module in [I-D.ahuang-netconf-notif-yang].
-   Furthermore, in Section 3.7 of [RFC8641], the subscription ID is
-   added to the "push-update" and "push-change-update" notification
-   messages allowing to recognize to which xpath or sub-tree the node
-   was subscribed to.
+   Section 4 of [RFC5277] describes the NETCONF event notification
+   header using a XML Schema.  In the metadata of the event notification
+   header, only the eventTime is present indicating at which time the
+   notification message was published.  For other encodings, the same
+   schema is implemented using a YANG module in
+   [I-D.ahuang-netconf-notif-yang].  Furthermore, in Section 3.7 of
+   [RFC8641], the subscription ID is added to the "push-update" and
+   "push-change-update" notification messages allowing to recognize to
+   which xpath or sub-tree the node was subscribed to.
 
    When the NETCONF event notification message is forwarded from the
    receiver to another system, such as a messaging system or a time
@@ -106,6 +101,11 @@ Table of Contents
    metadata.  Therefore, the downstream system is unable to associate
    the message to the publishing process (the exporting router), nor
    able to detect message loss or reordering.
+
+
+
+
+
 
 
 
@@ -146,8 +146,8 @@ Internet-Draft        YANG Notifications Sequencing           March 2023
    following metadata objects are part of a "push-update" and "push-
    change-update" notification message.
 
-   sysName:  Describes the hostname as specified in [RFC1213] from where
-      the message was published from.
+   sysName:  Describes the hostname following the 'sysName' object
+      definition in [RFC1213] from where the message was published from.
 
    sequenceNumber:  Generates a unique sequence number as described in
       [RFC9187] for each published message.
@@ -363,10 +363,10 @@ Internet-Draft        YANG Notifications Sequencing           March 2023
 
 6.1.  SysName Correlation
 
-   In order to allow data corelationamong BGP Monitoring Protocol (BMP)
-   [RFC7854] and YANG push, the same hostname value should be used as
-   described in section 4.4 of [RFC7854] for the information TLV in the
-   init BMP message type.
+   In order to allow data correlation among BGP Monitoring Protocol
+   (BMP) [RFC7854] and YANG push, the same hostname value should be used
+   as described in section 4.4 of [RFC7854] for the information TLV in
+   the init BMP message type.
 
 7.  Acknowledgements
 
@@ -472,11 +472,13 @@ Authors' Addresses
    Binzring 17
    CH-8045 Zurich
    Switzerland
+
    Email: thomas.graf@swisscom.com
 
 
    Jean Quilbeuf
    Huawei
+
    Email: jean.quilbeuf@huawei.com
 
 
@@ -484,10 +486,8 @@ Authors' Addresses
    INSA-Lyon
    Lyon
    France
+
    Email: alex.huang-feng@insa-lyon.fr
-
-
-
 
 
 

--- a/draft-tgraf-netconf-notif-sequencing-00.xml
+++ b/draft-tgraf-netconf-notif-sequencing-00.xml
@@ -74,14 +74,14 @@
       <t>This document specifies a new YANG module that augment the NETCONF
       Event Notification header to support hostname and sequence numbers to
       identify from which network node and at which time the message was
-      published. This allows to recognize loss, delay and reordering between
+      published. This allows the collector to recognize loss, delay and reordering between
       the publisher and the downstream system storing the message.</t>
     </abstract>
   </front>
 
   <middle>
     <section anchor="Introduction" title="Introduction">
-      <t><xref target="RFC5277"/> describes the NETCONF event notification
+      <t> Section 4 of <xref target="RFC5277"/> describes the NETCONF event notification
       header using a XML Schema. In the metadata of the event notification
       header, only the eventTime is present indicating at which time the
       notification message was published. For other encodings, the same schema
@@ -136,8 +136,8 @@
       <dl>
         <dt>sysName:</dt>
 
-        <dd>Describes the hostname as specified in <xref target="RFC1213"/>
-        from where the message was published from.</dd>
+        <dd>Describes the hostname following the 'sysName' object definition in <xref target="RFC1213"/>
+          from where the message was published from.</dd>
       </dl>
 
       <dl>
@@ -338,7 +338,7 @@ module ietf-notification-sequencing {
     <section anchor="Operational" title="Operational Considerations">
       <section anchor="operational_sysname_correlation"
                title="SysName Correlation">
-        <t>In order to allow data corelationamong BGP Monitoring Protocol
+        <t>In order to allow data correlation among BGP Monitoring Protocol
         (BMP) <xref target="RFC7854"/> and YANG push, the same hostname value
         should be used as described in section 4.4 of <xref target="RFC7854"/>
         for the information TLV in the init BMP message type.</t>


### PR DESCRIPTION
Just one comment about the reference for sysname.

In the draft we refer to RFC1213 which defines sysName as

>  sysName OBJECT-TYPE
>              SYNTAX  DisplayString (SIZE (0..255))
>              ACCESS  read-write
>              STATUS  mandatory
>              DESCRIPTION
>                      "An administratively-assigned name for this
>                      managed node.  By convention, this is the node's
>                      fully-qualified domain name."
>              ::= { system 5 }

In ietf-inet-types.yang, one the reference for 'host-name' is RFC1123 which states in section 2.1

> Whenever a user inputs the identity of an Internet host, it SHOULD
> be possible to enter either (1) a host domain name or (2) an IP
> address in dotted-decimal ("#.#.#.#") form.  The host SHOULD check
> the string syntactically for a dotted-decimal number before
> looking it up in the Domain Name System.

Just to make sure there is no confusion between 1123 and 1213.

In the update I assumed that we meant 1213.